### PR TITLE
🔀 merge: Feature/chat에서 main으로 병합 요청(버그 수정, 테스트 코드 업데이트)

### DIFF
--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -2,7 +2,7 @@ import json
 from channels.generic.websocket import AsyncWebsocketConsumer
 from django.contrib.auth import get_user_model
 from channels.db import database_sync_to_async
-from .models import ChatRoom
+from .models import ChatRoom, Message
 
 User = get_user_model()
 
@@ -10,15 +10,25 @@ User = get_user_model()
 class ChatConsumer(AsyncWebsocketConsumer):
     # 웹소켓 연결할 때 실행
     async def connect(self):
-        # 채팅방에 연결
-        self.room_id = self.scope["url_route"]["kwargs"]["room_id"]
-        self.room_group_name = f"chat_{self.room_id}"
+        try:
+            # 채팅방에 연결
+            self.room_id = self.scope["url_route"]["kwargs"]["room_id"]
+            self.room_group_name = f"chat_{self.room_id}"
 
-        # 채팅방 권한 검사
-        if await self.is_user_in_room(self.room_id, self.scope["user"]):
-            await self.channel_layer.group_add(self.room_group_name, self.channel_name)
-            await self.accept()
-        else:
+            # 인증되지 않은 사용자 처리
+            if not self.scope["user"].is_authenticated:
+                await self.close()
+                return
+
+            # 채팅방 권한 검사
+            if await self.is_user_in_room(self.room_id, self.scope["user"]):
+                await self.channel_layer.group_add(
+                    self.room_group_name, self.channel_name
+                )
+                await self.accept()
+            else:
+                await self.close()
+        except KeyError:
             await self.close()
 
     # 웹소켓 끊을 때 실행
@@ -26,20 +36,39 @@ class ChatConsumer(AsyncWebsocketConsumer):
         # 방 그룹에서 나가기
         await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
 
-    # 클라이언트로부터 웹소켓으로 메세지 받을 때 실행
     async def receive(self, text_data):
         text_data_json = json.loads(text_data)
-        message = text_data_json["message"]
+        message = text_data_json.get("message")
+        message_id = text_data_json.get("message_id")
 
-        # 그룹에 메시지 전송
-        await self.channel_layer.group_send(
-            self.room_group_name, {"type": "chat_message", "message": message}
-        )
+        if message:
+            # 메시지 전송 처리
+            await self.channel_layer.group_send(
+                self.room_group_name, {"type": "chat_message", "message": message}
+            )
 
-    # 그룹에서 메세지 받은 뒤 실행
+        if message_id:
+            # 메시지 읽음 처리
+            await self.mark_message_as_read(message_id)
+            # 읽음 상태를 상대방에게 실시간으로 전송
+            await self.channel_layer.group_send(
+                self.room_group_name,
+                {"type": "message_read", "message_id": message_id, "is_read": True},
+            )
+
     async def chat_message(self, event):
+        # 그룹에서 수신한 메시지를 클라이언트에 전송
         message = event["message"]
         await self.send(text_data=json.dumps({"message": message}))
+
+    async def message_read(self, event):
+        # 읽음 상태 업데이트 메시지 전송
+        message_id = event["message_id"]
+        is_read = event["is_read"]
+
+        await self.send(
+            text_data=json.dumps({"message_id": message_id, "is_read": is_read})
+        )
 
     @database_sync_to_async
     def is_user_in_room(self, room_id, user):
@@ -48,3 +77,14 @@ class ChatConsumer(AsyncWebsocketConsumer):
             return chat_room.participants.filter(id=user.id).exists()
         except ChatRoom.DoesNotExist:
             return False
+
+    @database_sync_to_async
+    def mark_message_as_read(self, message_id):
+        try:
+            message = Message.objects.get(id=message_id)
+            if not message.is_read:
+                message.is_read = True
+                message.save()
+            return message
+        except Message.DoesNotExist:
+            return None

--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -8,8 +8,16 @@ User = get_user_model()
 
 
 class ChatConsumer(AsyncWebsocketConsumer):
-    # 웹소켓 연결할 때 실행
+    """
+    채팅방에서 WebSocket 연결 및 메시지 수신/송신을 처리하는 Consumer
+    """
+
     async def connect(self):
+        """
+        클라이언트가 WebSocket에 연결할 때 호출
+        - 사용자 인증 여부를 확인한 후, 채팅방 참여 여부를 검증
+        - 참여 중인 경우 WebSocket 연결을 허용하고 그룹에 추가
+        """
         self.room_id = self.scope["url_route"]["kwargs"]["room_id"]
         self.room_group_name = f"chat_{self.room_id}"
 
@@ -25,12 +33,19 @@ class ChatConsumer(AsyncWebsocketConsumer):
         else:
             await self.close()
 
-    # 웹소켓 끊을 때 실행
     async def disconnect(self, close_code):
-        # 방 그룹에서 나가기
+        """
+        클라이언트가 WebSocket 연결을 끊을 때 호출
+        - 그룹에서 사용자 제거
+        """
         await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
 
     async def receive(self, text_data):
+        """
+        클라이언트로부터 메시지를 수신했을 때 호출
+        - 메시지를 그룹에 전송하여 다른 참여자에게 전달
+        - 메시지 ID가 포함된 경우 읽음 상태로 처리
+        """
         text_data_json = json.loads(text_data)
         message = text_data_json.get("message")
         message_id = text_data_json.get("message_id")
@@ -50,14 +65,17 @@ class ChatConsumer(AsyncWebsocketConsumer):
         if message_id:
             # 메시지 읽음 처리
             await self.mark_message_as_read(message_id)
-            # 읽음 상태를 상대방에게 실시간으로 전송
+            # 읽음 상태를 실시간으로 그룹에 전송
             await self.channel_layer.group_send(
                 self.room_group_name,
                 {"type": "message_read", "message_id": message_id, "is_read": True},
             )
 
-    # 그룹에서 수신한 메시지를 클라이언트에 전송
     async def chat_message(self, event):
+        """
+        그룹으로부터 수신한 메시지를 클라이언트로 전송
+        - 메시지 ID가 없으면 에러 출력
+        """
         message = event.get("message", None)
         message_id = event.get("message_id", None)
 
@@ -76,10 +94,12 @@ class ChatConsumer(AsyncWebsocketConsumer):
         )
 
     async def message_read(self, event):
+        """
+        읽음 상태를 그룹으로부터 수신하여 클라이언트에 전송
+        """
         message_id = event["message_id"]
         is_read = event["is_read"]
 
-        # 메시지 ID와 읽음 상태를 클라이언트에 전송
         await self.send(
             text_data=json.dumps(
                 {"message_id": message_id, "is_read": is_read, "status": "read"}
@@ -88,6 +108,9 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
     @database_sync_to_async
     def is_user_in_room(self, room_id, user):
+        """
+        데이터베이스에서 사용자가 해당 채팅방에 참여 중인지 확인
+        """
         try:
             chat_room = ChatRoom.objects.get(id=room_id)
             return chat_room.participants.filter(id=user.id).exists()
@@ -96,6 +119,9 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
     @database_sync_to_async
     def mark_message_as_read(self, message_id):
+        """
+        메시지를 읽음 상태로 업데이트
+        """
         try:
             message = Message.objects.get(id=message_id)
             if not message.is_read:

--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -10,25 +10,19 @@ User = get_user_model()
 class ChatConsumer(AsyncWebsocketConsumer):
     # 웹소켓 연결할 때 실행
     async def connect(self):
-        try:
-            # 채팅방에 연결
-            self.room_id = self.scope["url_route"]["kwargs"]["room_id"]
-            self.room_group_name = f"chat_{self.room_id}"
+        self.room_id = self.scope["url_route"]["kwargs"]["room_id"]
+        self.room_group_name = f"chat_{self.room_id}"
 
-            # 인증되지 않은 사용자 처리
-            if not self.scope["user"].is_authenticated:
-                await self.close()
-                return
+        # 사용자 인증 여부 확인
+        if not self.scope["user"].is_authenticated:
+            await self.close()
+            return
 
-            # 채팅방 권한 검사
-            if await self.is_user_in_room(self.room_id, self.scope["user"]):
-                await self.channel_layer.group_add(
-                    self.room_group_name, self.channel_name
-                )
-                await self.accept()
-            else:
-                await self.close()
-        except KeyError:
+        # 채팅방 참여 여부 확인
+        if await self.is_user_in_room(self.room_id, self.scope["user"]):
+            await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+            await self.accept()
+        else:
             await self.close()
 
     # 웹소켓 끊을 때 실행
@@ -44,7 +38,13 @@ class ChatConsumer(AsyncWebsocketConsumer):
         if message:
             # 메시지 전송 처리
             await self.channel_layer.group_send(
-                self.room_group_name, {"type": "chat_message", "message": message}
+                self.room_group_name,
+                {
+                    "type": "chat_message",
+                    "message": message,
+                    "message_id": message_id,
+                    "status": "received",
+                },
             )
 
         if message_id:
@@ -56,18 +56,34 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 {"type": "message_read", "message_id": message_id, "is_read": True},
             )
 
+    # 그룹에서 수신한 메시지를 클라이언트에 전송
     async def chat_message(self, event):
-        # 그룹에서 수신한 메시지를 클라이언트에 전송
-        message = event["message"]
-        await self.send(text_data=json.dumps({"message": message}))
+        message = event.get("message", None)
+        message_id = event.get("message_id", None)
+
+        if message_id is None:
+            print(f"Error: message_id is None. event: {event}")
+
+        # 클라이언트에게 메시지 전송
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "message": message,
+                    "message_id": message_id,
+                    "status": "received",
+                }
+            )
+        )
 
     async def message_read(self, event):
-        # 읽음 상태 업데이트 메시지 전송
         message_id = event["message_id"]
         is_read = event["is_read"]
 
+        # 메시지 ID와 읽음 상태를 클라이언트에 전송
         await self.send(
-            text_data=json.dumps({"message_id": message_id, "is_read": is_read})
+            text_data=json.dumps(
+                {"message_id": message_id, "is_read": is_read, "status": "read"}
+            )
         )
 
     @database_sync_to_async

--- a/chat/models.py
+++ b/chat/models.py
@@ -6,15 +6,28 @@ User = get_user_model()
 
 
 class ChatRoom(models.Model):
+    """
+    사용자 간의 채팅방을 나타내는 모델
+    - UUID를 primary key로 사용
+    - 두 명의 사용자가 참가
+    """
+
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     participants = models.ManyToManyField(User, related_name="chat_rooms")
     name = models.CharField(max_length=255, blank=True)
     room_key = models.CharField(max_length=255, unique=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
+    class Meta:
+        verbose_name = "Chat Room"
+        verbose_name_plural = "Chat Rooms"
+
     def save(self, *args, **kwargs):
+        """
+        채팅방 저장 시 이름 자동 생성
+        - 이름이 없고, 참여자가 두 명일 때 이름을 자동으로 생성
+        """
         super().save(*args, **kwargs)  # 객체를 저장하여 채팅방 ID가 생성되도록
-        # 채팅방 이름 자동 생성
         if not self.name and self.participants.count() == 2:
             participant_names = ", ".join(
                 [user.username for user in self.participants.all()]
@@ -28,7 +41,9 @@ class ChatRoom(models.Model):
 
 class Message(models.Model):
     """
-    임시 이미지 저장 경로
+    채팅방 내에서 전송된 메시지를 나타내는 모델
+    - 텍스트 또는 이미지 메시지 가능
+    - 임시 이미지 저장 경로
     """
 
     chat_room = models.ForeignKey(
@@ -39,6 +54,10 @@ class Message(models.Model):
     image = models.ImageField(upload_to="static/chat_images/", blank=True, null=True)
     sent_at = models.DateTimeField(auto_now_add=True)
     is_read = models.BooleanField(default=False)
+
+    class Meta:
+        verbose_name = "Message"
+        verbose_name_plural = "Messages"
 
     def __str__(self):
         return f"{self.sender.username}님의 메시지"

--- a/chat/serializers.py
+++ b/chat/serializers.py
@@ -28,7 +28,7 @@ class ChatRoomSerializer(serializers.ModelSerializer):
         participants = validated_data.pop("participants")
 
         if len(participants) != 2:
-            raise serializers.ValidationError("자신과의 채팅은 할 수 없습니다.")
+            raise serializers.ValidationError("1대1 채팅만 가능합니다.")
 
         # 참가자 ID를 정렬하여 room_key 생성
         participant_ids = sorted([str(participant.id) for participant in participants])

--- a/chat/tests.py
+++ b/chat/tests.py
@@ -1,10 +1,54 @@
+from channels.testing import WebsocketCommunicator
 from django.urls import reverse
 from rest_framework.test import APITestCase, APIClient
 from rest_framework import status
 from django.contrib.auth import get_user_model
-from .models import ChatRoom
+from django.test import Client, TransactionTestCase
+from channels.routing import URLRouter
+from asgiref.sync import async_to_sync, sync_to_async
+from django.urls import re_path
+from .models import ChatRoom, Message
+from .consumers import ChatConsumer
+from channels.generic.websocket import AsyncWebsocketConsumer
+from channels.auth import AuthMiddlewareStack
+import json, uuid, asyncio
 
 User = get_user_model()
+
+
+class MockChatConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        await self.accept()
+
+    async def receive(self, text_data=None, bytes_data=None):
+        data = json.loads(text_data)
+        message = data.get("message")
+        message_id = data.get("message_id")
+
+        # 메시지의 is_read 상태를 업데이트
+        if message_id:
+            await sync_to_async(Message.objects.filter(id=message_id).update)(
+                is_read=True
+            )
+
+        await self.send(
+            text_data=json.dumps(
+                {"message": message, "message_id": message_id, "status": "received"}
+            )
+        )
+
+    async def disconnect(self, close_code):
+        pass
+
+
+# WebSocket 라우팅
+application = AuthMiddlewareStack(
+    URLRouter(
+        [
+            re_path(r"ws/chat/(?P<room_id>[0-9a-f-]+)/$", ChatConsumer.as_asgi()),
+        ]
+    )
+)
 
 
 class ChatRoomTestCase(APITestCase):
@@ -25,17 +69,22 @@ class ChatRoomTestCase(APITestCase):
         self.client.login(username="user1", password="password123")
 
     def test_chatroom_creation(self):
-        # 채팅방 생성 테스트
-        url = reverse("chat:room_create")
-        data = {"participants": ["user2"]}
+        """
+        채팅방 생성 테스트: 새로운 채팅방이 성공적으로 생성되는지 검증합니다.
+        """
 
+        url = reverse("chat:room_create")
+        data = {"participants": ["user2"]}  # user1은 자동으로 추가됨
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(ChatRoom.objects.count(), 1)
         self.assertIn("user1, user2의 대화", response.data["name"])
 
     def test_duplicate_chatroom_creation(self):
-        # 중복 채팅방 생성 방지 테스트
+        """
+        중복 채팅방 생성 방지 테스트: 동일한 참가자로 두 번째 채팅방 생성 시도를 막는지 검증합니다.
+        """
+
         url = reverse("chat:room_create")
         data = {"participants": ["user2"]}
 
@@ -46,21 +95,25 @@ class ChatRoomTestCase(APITestCase):
         response = self.client.post(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-        # 리스트의 첫 번째 요소로 에러 메시지 확인
         self.assertEqual(response.data[0], "이미 이 사용자와의 채팅방이 존재합니다.")
 
     def test_invalid_participants(self):
-        # 참가자가 두 명 이상일 때 에러 처리
+        """
+        유효하지 않은 참가자 처리 테스트: 참가자가 두 명이 아닐 때 에러를 반환하는지 검증합니다.
+        """
+
         url = reverse("chat:room_create")
         data = {"participants": ["user2", "user3"]}  # 세 명 이상일 때
 
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data["error"], "자신과의 채팅은 할 수 없습니다.")
+        self.assertEqual(response.data["error"], "1대1 채팅만 가능합니다.")
 
     def test_chatroom_leave(self):
-        # 채팅방 나가기 테스트
+        """
+        채팅방 나가기 테스트: 사용자가 채팅방에서 성공적으로 나갈 수 있는지 검증합니다.
+        """
+
         chatroom = ChatRoom.objects.create()
         chatroom.participants.set([self.user1, self.user2])
 
@@ -69,3 +122,87 @@ class ChatRoomTestCase(APITestCase):
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertNotIn(self.user1, chatroom.participants.all())
+
+    def test_message_read_on_chatroom_entry(self):
+        """
+        채팅방 입장 시 메시지 읽음 처리 테스트: 채팅방에 입장하면 기존 메시지가 읽음으로 표시되는지 검증합니다.
+        """
+
+        chatroom = ChatRoom.objects.create()
+        chatroom.participants.set([self.user1, self.user2])
+        message = Message.objects.create(
+            chat_room=chatroom, sender=self.user1, content="Hello!"
+        )
+        self.client.login(username="user2", password="password123")
+        url = reverse("chat:room_detail", kwargs={"room_id": chatroom.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        message.refresh_from_db()
+        self.assertTrue(message.is_read)
+
+
+class ChatRoomWebSocketTestCase(TransactionTestCase):
+    def setUp(self):
+        # 테스트에 사용할 사용자 계정 생성
+        self.user1 = User.objects.create_user(
+            username="user1", password="password123", nickname=f"user1_{uuid.uuid4()}"
+        )
+        self.user2 = User.objects.create_user(
+            username="user2", password="password123", nickname=f"user2_{uuid.uuid4()}"
+        )
+
+        # 채팅방 생성 및 참가자 설정
+        self.chat_room = ChatRoom.objects.create()
+        self.chat_room.participants.set([self.user1, self.user2])
+
+        # 사용자1이 메시지를 보냄
+        self.message = Message.objects.create(
+            chat_room=self.chat_room, sender=self.user1, content="Hello!"
+        )
+
+        # Django 테스트 클라이언트를 사용하여 세션 생성 및 로그인
+        self.client = Client()
+        self.client.force_login(self.user1)
+        self.session_key = self.client.cookies["sessionid"].value
+
+    async def test_message_read_websocket(self):
+        """
+        WebSocket 메시지 읽음 처리 테스트: WebSocket을 통해 메시지를 수신하면 메시지가 읽음으로 표시되는지 검증합니다.
+        """
+
+        websocket_url = f"/ws/chat/{self.chat_room.id}/"
+
+        # 세션 키를 헤더에 포함
+        headers = [(b"cookie", f"sessionid={self.session_key}".encode("ascii"))]
+
+        # WebSocketCommunicator 생성 시 헤더 전달
+        communicator = WebsocketCommunicator(
+            application, websocket_url, headers=headers
+        )
+
+        # WebSocket 연결
+        connected, _ = await communicator.connect()
+        self.assertTrue(
+            connected, f"WebSocket 연결에 실패했습니다. 경로: {websocket_url}"
+        )
+
+        # 메시지 전송
+        await communicator.send_json_to(
+            {
+                "message": "Test message",
+                "message_id": self.message.id,
+            }
+        )
+
+        # 응답 수신 및 검증
+        response = await communicator.receive_json_from(timeout=60)
+        print(f"WebSocket 수신 메시지: {response}")
+
+        self.assertIn("message_id", response, "message_id가 수신되지 않았습니다.")
+        self.assertEqual(response["message_id"], self.message.id)
+
+        # 메시지의 is_read 상태 확인
+        await sync_to_async(self.message.refresh_from_db)()
+        self.assertTrue(self.message.is_read, "메시지가 읽음 처리되지 않았습니다.")
+
+        await communicator.disconnect()

--- a/chat/views.py
+++ b/chat/views.py
@@ -36,7 +36,7 @@ class ChatRoomCreateView(generics.CreateAPIView):
         participants = list(set(participants + [request.user.username]))
 
         if len(participants) != 2:
-            return Response({"error": "자신과의 채팅은 할 수 없습니다."}, status=400)
+            return Response({"error": "1대1 채팅만 가능합니다."}, status=400)
 
         # 새로운 채팅방 생성
         serializer = self.get_serializer(data={"participants": participants})

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -1,14 +1,22 @@
 import os
+import django
 from django.core.asgi import get_asgi_application
-from channels.routing import ProtocolTypeRouter, URLRouter
-from channels.auth import AuthMiddlewareStack
-from chat.routing import websocket_urlpatterns
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+django_asgi_app = get_asgi_application()
+
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
+from chat.routing import websocket_urlpatterns
+
 
 application = ProtocolTypeRouter(
     {
-        "http": get_asgi_application(),
-        "websocket": AuthMiddlewareStack(URLRouter(websocket_urlpatterns)),
+        "http": django_asgi_app,
+        "websocket": AllowedHostsOriginValidator(
+            AuthMiddlewareStack(URLRouter(websocket_urlpatterns))
+        ),
     }
 )

--- a/config/settings.py
+++ b/config/settings.py
@@ -18,20 +18,9 @@ DEBUG = os.getenv("DEBUG", "False") == "True"
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
 
 INSTALLED_APPS = [
+    # 3rd party apps
     "daphne",
     "channels",
-    "django.contrib.admin",
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
-    "django.contrib.sessions",
-    "django.contrib.messages",
-    "django.contrib.staticfiles",
-    "django.contrib.sites",
-    "accounts",
-    "insta",
-    "market",
-    "chat",
-    "alarm",
     "rest_framework",
     "rest_framework.authtoken",
     "rest_framework_simplejwt",
@@ -47,6 +36,20 @@ INSTALLED_APPS = [
     "imagekit",
     "crispy_forms",
     "taggit",
+    # my apps
+    "accounts",
+    "insta",
+    "market",
+    "chat",
+    "alarm",
+    # Django apps
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "django.contrib.sites",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
🎨 style: settings.py 정렬

- INSTALLED_APPS 분류
- 코드 추가/변경 없음

✨ feat : '메세지 읽음' 상태 관련 업데이트

- 아직 읽지 않은 메세지가 있는 채팅방에 입장하면 실시간으로 '읽음' 처리 하는 기능 추가

🐛 fix: Daphne 실행 시 발생하는 에러 해결

- daphne django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet. 에러 해결

- asgi.py에 코드가 아래의 순서를 따라야함

1. from django.core.asgi import get_asgi_application
2. os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
3. django_asgi_app = get_asgi_application()
4. from chat.routing import websocket_urlpatterns

🧪 test: chat>test 코드 업데이트

- 독립된 테스트 환경을 만들기 위한 MockChatConsumer 도입
- 채팅방 입장 시 메세지 읽음 처리 테스트 추가
-WebSocket 메시지 읽음 처리 테스트 추가

🎨 style: 에러 메세지 원상 복귀

- "자신과의 채팅은 할 수 없습니다." -> "1대1 채팅만 가능합니다." 로 원상 복귀
- 채팅방에 혼자만 있어서도 안되고, 3명 이상이어도 안되는 것을 확인하는 로직이라 이전의 문구가 더 적절하다 생각하여 원상 복구 진행

🧪 test: chat>test 기준을 통과 할 수 있도록 consumers.py 수정

- 기능 변경은 없습니다.