### PR TITLE
🔀 merge: Feature/alarm에서 main으로 병합 요청(코드 정리, 의도하지 않은 '메시지 is_read' 에 대한 문제점 해결)

### DIFF
--- a/alarm/models.py
+++ b/alarm/models.py
@@ -25,11 +25,9 @@ class Alarm(models.Model):
     sender = models.ForeignKey(
         User, related_name="sent_alarms", on_delete=models.CASCADE
     )  # 알림을 발생시킨 사용자
-    alarm_type = models.CharField(
-        max_length=20, choices=ALARM_TYPE_CHOICES
-    )  # 알림 종류
-    message = models.TextField(blank=True, null=True)  # 알림 메시지
-    created_at = models.DateTimeField(auto_now_add=True)  # 알림 생성 시각
+    alarm_type = models.CharField(max_length=20, choices=ALARM_TYPE_CHOICES)
+    message = models.TextField(blank=True, null=True)
+    created_at = models.DateTimeField(auto_now_add=True)
     related_object_id = models.UUIDField(
         null=True, blank=True
     )  # 연관된 객체의 ID, 리디렉션 용

--- a/alarm/signals.py
+++ b/alarm/signals.py
@@ -77,11 +77,11 @@ def create_alarm_for_new_follower(sender, instance, created, **kwargs):
     if created:
         # 팔로우가 생성되었을 때 팔로우된 사람에게 알림 생성
         recipient = instance.following
-        sender_user = instance.follower
+        sender = instance.follower
 
         Alarm.objects.create(
             recipient=recipient,
-            sender=sender_user,
+            sender=sender,
             alarm_type="follow",
             message=f"{sender.username}님이 당신을 팔로우했습니다.",
             related_object_id=None,  # 팔로우는 연결된 객체가 없으므로 None
@@ -96,13 +96,13 @@ def create_alarm_for_new_comment(sender, instance, created, **kwargs):
     if created:
         # 댓글이 달린 게시물의 작성자에게 알림 생성
         recipient = instance.post.user  # 게시물 작성자
-        sender_user = instance.user  # 댓글 작성자
+        sender = instance.user  # 댓글 작성자
 
         Alarm.objects.create(
             recipient=recipient,
-            sender=sender_user,
+            sender=sender,
             alarm_type="comment",
-            message=f"{sender_user.username}님이 게시물에 댓글을 남겼습니다.",
+            message=f"{sender.username}님이 게시물에 댓글을 남겼습니다.",
             related_object_id=instance.post.id,
         )
 
@@ -115,12 +115,12 @@ def create_alarm_for_new_like(sender, instance, created, **kwargs):
     if created:
         # 좋아요가 달린 게시물의 작성자에게 알림 생성
         recipient = instance.post.user  # 게시물 작성자
-        sender_user = instance.user  # 좋아요를 남긴 사용자
+        sender = instance.user  # 좋아요를 남긴 사용자
 
         Alarm.objects.create(
             recipient=recipient,
-            sender=sender_user,
+            sender=sender,
             alarm_type="like",
-            message=f"{sender_user.username}님이 게시물을 좋아합니다.",
+            message=f"{sender.username}님이 게시물을 좋아합니다.",
             related_object_id=instance.post.id,
         )

--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -33,6 +33,9 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
             # WebSocket 연결 정보를 저장
             await self.record_connection(self.scope["user"], self.room_id)
+
+            # 채팅방 내 읽지 않은 메시지를 읽음 처리
+            await self.mark_messages_as_read(self.room_id, self.scope["user"])
         else:
             await self.close()
 
@@ -68,10 +71,11 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 },
             )
 
-        if message_id:
             # 메시지 읽음 처리
+            await self.mark_messages_as_read(self.room_id, self.scope["user"])
+
+        if message_id:
             await self.mark_message_as_read(message_id)
-            # 읽음 상태를 실시간으로 그룹에 전송
             await self.channel_layer.group_send(
                 self.room_group_name,
                 {"type": "message_read", "message_id": message_id, "is_read": True},
@@ -80,13 +84,9 @@ class ChatConsumer(AsyncWebsocketConsumer):
     async def chat_message(self, event):
         """
         그룹으로부터 수신한 메시지를 클라이언트로 전송
-        - 메시지 ID가 없으면 에러 출력
         """
         message = event.get("message", None)
         message_id = event.get("message_id", None)
-
-        if message_id is None:
-            print(f"Error: message_id is None. event: {event}")
 
         # 클라이언트에게 메시지 전송
         await self.send(
@@ -146,9 +146,19 @@ class ChatConsumer(AsyncWebsocketConsumer):
             connection.mark_disconnected()
 
     @database_sync_to_async
-    def mark_message_as_read(self, message_id):
+    def mark_all_messages_as_read(self, room_id, user):
         """
-        메시지를 읽음 상태로 업데이트
+        사용자가 채팅방에 입장할 때, 읽지 않은 메시지를 모두 읽음 처리
+        """
+        chat_room = ChatRoom.objects.get(id=room_id)
+        Message.objects.filter(chat_room=chat_room, is_read=False).exclude(
+            sender=user
+        ).update(is_read=True)
+
+    @database_sync_to_async
+    def mark_single_message_as_read(self, message_id):
+        """
+        실시간 전송된 개별 메시지를 읽음 상태로 업데이트
         """
         try:
             message = Message.objects.get(id=message_id)

--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -146,7 +146,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
             connection.mark_disconnected()
 
     @database_sync_to_async
-    def mark_all_messages_as_read(self, room_id, user):
+    def mark_messages_as_read(self, room_id, user):
         """
         사용자가 채팅방에 입장할 때, 읽지 않은 메시지를 모두 읽음 처리
         """
@@ -156,7 +156,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
         ).update(is_read=True)
 
     @database_sync_to_async
-    def mark_single_message_as_read(self, message_id):
+    def mark_message_as_read(self, message_id):
         """
         실시간 전송된 개별 메시지를 읽음 상태로 업데이트
         """

--- a/chat/tests.py
+++ b/chat/tests.py
@@ -149,10 +149,15 @@ class ChatRoomTestCase(APITestCase):
         message = Message.objects.create(
             chat_room=chatroom, sender=self.user1, content="Hello!"
         )
+
+        # user2로 로그인하고 채팅방 입장
         self.client.login(email="newuser2@example.com", password="newpassword123")
         url = reverse("chat:room_detail", kwargs={"room_id": chatroom.id})
         response = self.client.get(url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # 메시지가 읽음 처리되었는지 확인
         message.refresh_from_db()
         self.assertTrue(message.is_read)
 
@@ -161,38 +166,24 @@ class ChatRoomTestCase(APITestCase):
         채팅방 메시지 검색 테스트: 키워드를 포함하는 메시지가 반환되는지 검증
         존재하지 않는 키워드로 검색 시 '검색된 메시지가 없습니다' 반환
         """
-        chatroom = ChatRoom.objects.filter(
-            participants__in=[self.user1, self.user2]
-        ).first()
-        if not chatroom:
-            chatroom = ChatRoom.objects.create()
-            chatroom.participants.set([self.user1, self.user2])
+        chatroom = ChatRoom.objects.create()
+        chatroom.participants.set([self.user1, self.user2])
 
         # 검색할 메시지 생성
         Message.objects.create(
             chat_room=chatroom, sender=self.user1, content="안녕하세요"
         )
 
-        # URL 확인을 위한 로그 추가
         url = reverse("chat:message_search", kwargs={"room_id": chatroom.id})
-        print(f"검색 URL: {url}")
 
-        # 1. 키워드 '안녕'으로 검색하여 '안녕하세요' 메시지를 찾는 테스트
-        url = reverse("chat:message_search", kwargs={"room_id": chatroom.id})
+        # 키워드 '안녕'으로 검색하여 '안녕하세요' 메시지를 찾는 테스트
         response = self.client.get(url, {"q": "안녕"}, format="json")
-
-        # 응답 상태 코드 로그 추가
-        print(f"응답 상태 코드: {response.status_code}")
-
-        # 검색된 메시지가 있을 때
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["content"], "안녕하세요")
 
-        # 2. 존재하지 않는 메시지를 검색
+        # 존재하지 않는 메시지를 검색
         response = self.client.get(url, {"q": "없는 메시지"}, format="json")
-
-        # 검색된 메시지가 없을 때
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("message", response.data)
         self.assertEqual(response.data["message"], "검색된 메시지가 없습니다.")
@@ -262,8 +253,6 @@ class ChatRoomWebSocketTestCase(TransactionTestCase):
 
         # 응답 수신 및 검증
         response = await communicator.receive_json_from(timeout=60)
-        print(f"WebSocket 수신 메시지: {response}")
-
         self.assertIn("message_id", response, "message_id가 수신되지 않았습니다.")
         self.assertEqual(response["message_id"], self.message.id)
 

--- a/chat/tests.py
+++ b/chat/tests.py
@@ -65,6 +65,11 @@ class ChatRoomTestCase(APITestCase):
         """
         테스트용 사용자 생성 및 로그인 처리
         """
+        # 데이터 초기화
+        ChatRoom.objects.all().delete()
+        Message.objects.all().delete()
+
+        # 사용자 생성
         self.user1 = User.objects.create_user(
             email="newuser1@example.com",
             password="newpassword123",

--- a/chat/views.py
+++ b/chat/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import get_object_or_404
 from django.contrib.auth import get_user_model
-from rest_framework import generics, permissions, status
+from rest_framework import generics, status, filters
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiParameter
 from drf_spectacular.types import OpenApiTypes
@@ -23,7 +24,7 @@ class ChatRoomListView(generics.ListAPIView):
     """
 
     serializer_class = ChatRoomSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsAuthenticated]
 
     @extend_schema(
         summary="채팅방 목록 조회",
@@ -47,7 +48,7 @@ class ChatRoomCreateView(generics.CreateAPIView):
     """
 
     serializer_class = ChatRoomSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsAuthenticated]
     queryset = ChatRoom.objects.all()
 
     @extend_schema(
@@ -106,7 +107,7 @@ class ChatRoomDetailView(generics.RetrieveAPIView):
     """
 
     serializer_class = ChatRoomSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsAuthenticated]
     lookup_field = "id"
 
     @extend_schema(
@@ -143,7 +144,7 @@ class ChatRoomLeaveView(generics.DestroyAPIView):
     요청한 사용자가 채팅방을 나가고, 남은 참여자가 없으면 채팅방 삭제
     """
 
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsAuthenticated]
     serializer_class = None  # DestroyAPIView에서는 명시적으로 None으로 설정해야함
 
     @extend_schema(
@@ -174,7 +175,7 @@ class MessageListView(generics.ListAPIView):
     """
 
     serializer_class = MessageSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsAuthenticated]
 
     @extend_schema(
         summary="채팅방 메시지 목록 조회",
@@ -207,7 +208,7 @@ class MessageCreateView(generics.CreateAPIView):
     """
 
     serializer_class = MessageSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsAuthenticated]
 
     @extend_schema(
         summary="채팅방 메시지 생성",
@@ -238,7 +239,7 @@ class MessageSearchView(generics.ListAPIView):
     """
 
     serializer_class = MessageSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsAuthenticated]
 
     @extend_schema(
         summary="채팅방 메시지 검색",


### PR DESCRIPTION
실수로 브랜치를 바꾸지 않고 alarm 브랜치에서 작업했습니다. commit한 내용은 전부 chat앱에 관한 내용입니다.

🎨 style: 코드 정리, 불필요한 주석 제거, 기능 변화 없음

- test setup에 매 test 마다 데이터를 초기화하는 기능 추가

🐛 fix: 채팅 메시지 is_read 문제

- 기존의 코드는 채팅방에 입장하는 순간 모든 메시지의 is_read 필드를 True로 바꾸는 방식
- 해당 방식은 사용자 둘 다 채팅방에 접속해있는 상태에서 보내는 메시지들의 is_read 필드를 false로 만드는 문제를 발생시킴
- 기존의 '채팅방에 입장하는 순간 모든 메시지를 읽음 처리' 하는 기능을 유지하며, 실시간으로 전송된 개별 메시지에 대한 읽음 처리를 추가
- 상대방이 웹소켓에 연결되어 있는 상태라면, 내가 보낸 메시지에 대한 is_read 필드를 즉시 true로 처리하는 로직을 추가
- 기능 변화에따른 테스트 코드 수정

🐛 fix: 메서드 이름 수정 이전으로 되돌림

- mark_message_as_read 메서드를 일괄, 개별로 세분화함에 따라 이름을 변경했는데 문제가 발생하여 이전으로 되돌림

🐛 fix: sender_user -> sender 로 에러 발생 이전으로 되돌림